### PR TITLE
fix: sizing issues on small screens

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -19,12 +19,12 @@ export default function Page() {
           alignItems="center"
           container
           justifyContent="center"
-          sx={{ width: "100%", height: "70vh", p: 4 }}
+          sx={{ width: "100%", height: "70vh", p: { xs: 0, sm: 2, md: 4 } }}
         >
           <Grid>
             <Typography
               color="textSecondary"
-              fontSize={{ md: "12rem", lg: "16rem" }}
+              fontSize={{ xs: "20vw", md: "12rem", lg: "16rem" }}
               fontWeight={600}
               textAlign="center"
               variant="h1"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,1 +1,12 @@
 @import url(https://fonts.googleapis.com/icon?family=Material+Icons);
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  max-width: 100%;
+  overflow-x: hidden;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,12 +6,17 @@ import { ThemeProvider } from "@mui/material/styles";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v15-appRouter";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 
 import Footer from "~/components/layout/Footer";
 import Nav from "~/components/layout/Nav";
 import { roboto } from "~/style/font";
 import theme from "~/style/theme";
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
 
 export const metadata: Metadata = {
   title: "Portfolio of George Madeley",

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -19,12 +19,7 @@ interface PageProps {
 export default async function Page({ searchParams }: PageProps) {
   const awaitedSearchParams = await searchParams;
 
-  // const currentYear = new Date(Date.now()).getFullYear();
-
   const page = awaitedSearchParams.page ? Number(awaitedSearchParams.page) : 1;
-  // const year = awaitedSearchParams.year
-  //   ? Number(awaitedSearchParams.year)
-  //   : currentYear;
 
   return (
     <MeshBackground>
@@ -33,12 +28,12 @@ export default async function Page({ searchParams }: PageProps) {
           alignItems="center"
           container
           justifyContent="center"
-          sx={{ width: "100%", height: "70vh", p: 4 }}
+          sx={{ width: "100%", height: "70vh", p: { xs: 0, sm: 2, md: 4 } }}
         >
           <Grid>
             <Typography
               color="textSecondary"
-              fontSize={{ md: "12rem", lg: "16rem" }}
+              fontSize={{ xs: "20vw", md: "12rem", lg: "16rem" }}
               fontWeight={600}
               textAlign="center"
               variant="h1"
@@ -62,24 +57,17 @@ export default async function Page({ searchParams }: PageProps) {
                   source code (if available). If you have any questions about
                   any of these projects, please feel free to contact me.
                 </Typography>
-                {/* <Suspense
-                  fallback={
-                    <Skeleton
-                      height={"10rem"}
-                      variant="rectangular"
-                      width={"100%"}
-                    />
-                  }
-                >
-                  <CommitMap repo="*" year={year} />
-                </Suspense> */}
               </Stack>
             </CardContent>
           </Card>
           <Card>
             <CardContent>
               <Stack gap={2}>
-                <Typography fontWeight={700} variant="h2">
+                <Typography
+                  fontSize={{ xs: "13vw", sm: "3.75rem" }}
+                  fontWeight={700}
+                  variant="h2"
+                >
                   Repositories
                 </Typography>
                 <Suspense

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -30,7 +30,7 @@ export default function Hero({ tags }: HeroProps) {
       sx={{
         width: "100%",
         minHeight: "80vh",
-        p: 4,
+        p: { xs: 0, sm: 2, md: 4 },
       }}
     >
       <Grid
@@ -67,11 +67,10 @@ export default function Hero({ tags }: HeroProps) {
             Software Engineering at Atlantic Technology,
           </Typography>
         </Grid>
-        <Grid size={12}>
-          <Stack direction="row" flexWrap="wrap" gap={1}>
-            {tags.map((tag) => (
+        <Grid columnGap={1} container rowGap={1.5} size={12}>
+          {tags.map((tag) => (
+            <Grid key={tag} size="auto">
               <Chip
-                key={tag}
                 label={tag}
                 sx={{
                   color: "text.primary",
@@ -79,8 +78,8 @@ export default function Hero({ tags }: HeroProps) {
                     "rgba(var(--mui-palette-text-primaryChannel) / 0.1)",
                 }}
               />
-            ))}
-          </Stack>
+            </Grid>
+          ))}
         </Grid>
         <Grid size={12}>
           <Stack direction="row" flexWrap="wrap" gap={2}>
@@ -153,7 +152,7 @@ export default function Hero({ tags }: HeroProps) {
         alignItems="center"
         container
         size={{ sm: 12, md: "grow" }}
-        sx={{ height: "50vh" }}
+        sx={{ height: "50vh", display: { xs: "none", md: "flex" } }}
       >
         <WaveGridWrapper />
       </Grid>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -5,6 +5,7 @@ import LockIcon from "@mui/icons-material/Lock";
 import NoEncryptionIcon from "@mui/icons-material/NoEncryption";
 import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
+import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -151,9 +152,16 @@ export default async function Projects(props: ProjectsProps) {
                   <Button
                     endIcon={<ArrowForwardIcon />}
                     href={`/projects/${repo.name}?owner=${repo.owner.login}`}
+                    sx={{ display: { xs: "none", sm: "inline-flex" } }}
                   >
                     Learn more
                   </Button>
+                  <IconButton
+                    href={`/projects/${repo.name}?owner=${repo.owner.login}`}
+                    sx={{ display: { xs: "inline-flex", sm: "none" } }}
+                  >
+                    <ArrowForwardIcon />
+                  </IconButton>
                 </TableCell>
               </TableRow>
             ))}

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -52,7 +52,6 @@ export default function Nav() {
           width: "fit-content",
           m: 1,
           p: 0.5,
-          position: "fixed",
           zIndex: 1000,
         }}
       >


### PR DESCRIPTION
## Changes

- General responsive fixes for small screens,
- Fix the issue where MUI shrinks the root `<html>` and `<body>` elements when then screen width becomes less than `395px`. The fix is more of a patch which  ensures the `<html>` and `<body>` no longer shrink; the MUI script still attempts to shrink the elements